### PR TITLE
Added an optional animation parameter

### DIFF
--- a/OpenSeadragonHTMLelements.js
+++ b/OpenSeadragonHTMLelements.js
@@ -27,6 +27,7 @@
     //   element: <HTMLelement>,
     //   rect: <OpenSeadragon.Rect> in imageCoordinates,
     //   (optional) fontSize: number
+    //   (optional) animation: "zoom"|"pan"
     // }
     this.elements = []
 
@@ -88,12 +89,16 @@
       if (e !== null) {
         const vpRect = this.viewer.viewport.imageToViewportRectangle(e.rect)
         const vpPos = viewer.viewport.imageToViewportCoordinates(e.rect.x, e.rect.y)
-        this.viewer.viewport.fitBoundsWithConstraints(new OpenSeadragon.Rect(
-          vpPos.x - vpRect.width / 2,
-          vpPos.y - vpRect.height / 2,
-          vpRect.width,
-          vpRect.height
-        ))
+        if("animation" in e && e.animation == 'pan'){
+          this.viewer.viewport.panTo((new OpenSeadragon.Point(vpPos.x - vpRect.width / 2, vpPos.y - vpRect.height / 2)), false)
+        }else{
+          this.viewer.viewport.fitBoundsWithConstraints(new OpenSeadragon.Rect(
+              vpPos.x - vpRect.width / 2,
+              vpPos.y - vpRect.height / 2,
+              vpRect.width,
+              vpRect.height
+          ))
+        }
       }
     },
     moveElement: function(id, x, y) {

--- a/README.md
+++ b/README.md
@@ -23,11 +23,14 @@ hEl.addElement({
   y: 500,
   width: 4000,
   height: 2500,
-  (optional)fontSize: 14
+  (optional)fontSize: 14,
+  (optional)animation: "zoom"|"pan"
 })
 `````
 
 Optionally, for elements with text, a font size can be provided granting zoom in/out properties to the text. However, this is strongly unadvised, as changing font size on the fly causes a bad case of CSS jitter, seemingly unavoidable. It is advised that any text be converted into an image, for smoother experience.
+
+Optionally, an animation style can be added to pan to the element location or zoom in and fit it within the viewport.
 
 The following methods are provided, to be called on the HTMLelements object:
 


### PR DESCRIPTION
I am working on a project and came across this plugin for OpenSeadragon that's helps solve an issue I was having with adding overlays.

I added an optional animation parameter to switch between the fitBoundsWithConstraints and panTo methods on the viewport because I don't necessarily want to zoom in on the overlays - I just want to make sure they are centered in the viewport.